### PR TITLE
Add Azure DevOps repository support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ OPENAI_API_KEY=
 
 # OPTIONAL: providing your own GitHub PAT increases rate limits from 60/hr to 5000/hr to the GitHub API
 GITHUB_PAT=
+AZURE_PAT=
 
 # old implementation
 # OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can also replace `hub` with `diagram` in any Github URL to access its diagra
 ## 🚀 Features
 
 - 👀 **Instant Visualization**: Convert any GitHub repository structure into a system design / architecture diagram
+- 💙 **Azure Support**: Works with Azure DevOps repositories using the same workflow
 - 🎨 **Interactivity**: Click on components to navigate directly to source files and relevant directories
 - ⚡ **Fast Generation**: Powered by OpenAI o4-mini for quick and accurate diagrams
 - 🔄 **Customization**: Modify and regenerate diagrams with custom instructions

--- a/backend/app/services/azure_service.py
+++ b/backend/app/services/azure_service.py
@@ -1,0 +1,102 @@
+import requests
+import base64
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class AzureDevOpsService:
+    def __init__(self, pat: str | None = None):
+        self.azure_pat = pat or os.getenv("AZURE_PAT")
+
+    def _get_headers(self):
+        if not self.azure_pat:
+            return {"Accept": "application/json"}
+        token = base64.b64encode(f":{self.azure_pat}".encode()).decode()
+        return {
+            "Authorization": f"Basic {token}",
+            "Accept": "application/json",
+        }
+
+    def get_default_branch(self, organization: str, repo: str, project: str | None = None):
+        project = project or repo
+        api_url = (
+            f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repo}?api-version=7.0"
+        )
+        response = requests.get(api_url, headers=self._get_headers())
+        if response.status_code == 200:
+            data = response.json()
+            default_branch = data.get("defaultBranch")
+            if default_branch:
+                return default_branch.replace("refs/heads/", "")
+        return None
+
+    def get_repo_file_paths_as_list(self, organization: str, repo: str, project: str | None = None):
+        project = project or repo
+        branch = self.get_default_branch(organization, repo, project) or "main"
+        api_url = (
+            "https://dev.azure.com/"
+            f"{organization}/{project}/_apis/git/repositories/{repo}/items"
+            f"?recursionLevel=full&versionDescriptor.version={branch}&api-version=7.0"
+        )
+        response = requests.get(api_url, headers=self._get_headers())
+        if response.status_code != 200:
+            raise ValueError("Could not fetch repository file tree.")
+        data = response.json()
+
+        def should_include_file(path: str) -> bool:
+            excluded_patterns = [
+                "node_modules/",
+                "vendor/",
+                "venv/",
+                ".min.",
+                ".pyc",
+                ".pyo",
+                ".pyd",
+                ".so",
+                ".dll",
+                ".class",
+                ".jpg",
+                ".jpeg",
+                ".png",
+                ".gif",
+                ".ico",
+                ".svg",
+                ".ttf",
+                ".woff",
+                ".webp",
+                "__pycache__/",
+                ".cache/",
+                ".tmp/",
+                "yarn.lock",
+                "poetry.lock",
+                "*.log",
+                ".vscode/",
+                ".idea/",
+            ]
+            return not any(pattern in path.lower() for pattern in excluded_patterns)
+
+        paths = [
+            item["path"].lstrip("/")
+            for item in data.get("value", [])
+            if item.get("gitObjectType") == "blob" and should_include_file(item["path"])
+        ]
+        return "\n".join(paths)
+
+    def get_repo_readme(self, organization: str, repo: str, project: str | None = None):
+        project = project or repo
+        api_url = (
+            f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repo}/items"
+            "?path=/README.md&includeContent=true&api-version=7.0"
+        )
+        response = requests.get(api_url, headers=self._get_headers())
+        if response.status_code == 200:
+            data = response.json()
+            return data.get("content", "")
+        elif response.status_code == 404:
+            raise ValueError("No README found for the specified repository.")
+        else:
+            raise Exception(
+                f"Failed to fetch README: {response.status_code}, {response.text}"
+            )

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -232,3 +232,10 @@ class GitHubService:
         data = response.json()
         readme_content = requests.get(data["download_url"]).text
         return readme_content
+
+    # Alias methods for provider-agnostic usage
+    def get_repo_file_paths_as_list(self, username, repo):
+        return self.get_github_file_paths_as_list(username, repo)
+
+    def get_repo_readme(self, username, repo):
+        return self.get_github_readme(username, repo)

--- a/src/app/[username]/[repo]/page.tsx
+++ b/src/app/[username]/[repo]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import MainCard from "~/components/main-card";
 import Loading from "~/components/loading";
 import MermaidChart from "~/components/mermaid-diagram";
@@ -13,6 +13,8 @@ import { useStarReminder } from "~/hooks/useStarReminder";
 export default function Repo() {
   const [zoomingEnabled, setZoomingEnabled] = useState(false);
   const params = useParams<{ username: string; repo: string }>();
+  const searchParams = useSearchParams();
+  const provider = searchParams.get("provider") ?? "github";
 
   // Use the star reminder hook
   useStarReminder();
@@ -32,7 +34,11 @@ export default function Repo() {
     handleOpenApiKeyDialog,
     handleExportImage,
     state,
-  } = useDiagram(params.username.toLowerCase(), params.repo.toLowerCase());
+  } = useDiagram(
+    params.username.toLowerCase(),
+    params.repo.toLowerCase(),
+    provider,
+  );
 
   return (
     <div className="flex flex-col items-center p-4">
@@ -41,6 +47,7 @@ export default function Repo() {
           isHome={false}
           username={params.username.toLowerCase()}
           repo={params.repo.toLowerCase()}
+          provider={provider}
           showCustomization={!loading && !error}
           onModify={handleModify}
           onRegenerate={handleRegenerate}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -28,6 +28,7 @@ export function Header() {
   const handlePrivateReposSubmit = (pat: string) => {
     // Store the PAT in localStorage
     localStorage.setItem("github_pat", pat);
+    localStorage.setItem("azure_pat", pat);
     setIsPrivateReposDialogOpen(false);
   };
 

--- a/src/components/private-repos-dialog.tsx
+++ b/src/components/private-repos-dialog.tsx
@@ -20,7 +20,8 @@ export function PrivateReposDialog({
   const [pat, setPat] = useState<string>("");
 
   useEffect(() => {
-    const storedPat = localStorage.getItem("github_pat");
+    const storedPat =
+      localStorage.getItem("github_pat") || localStorage.getItem("azure_pat");
     if (storedPat) {
       setPat(storedPat);
     }
@@ -34,6 +35,7 @@ export function PrivateReposDialog({
 
   const handleClear = () => {
     localStorage.removeItem("github_pat");
+    localStorage.removeItem("azure_pat");
     setPat("");
   };
 
@@ -42,13 +44,13 @@ export function PrivateReposDialog({
       <DialogContent className="border-[3px] border-black bg-purple-200 p-6 shadow-[8px_8px_0_0_#000000] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-black">
-            Enter GitHub Personal Access Token
+            Enter Personal Access Token
           </DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="text-sm">
-            To enable private repositories, you&apos;ll need to provide a GitHub
-            Personal Access Token with repo scope. The token will be stored
+            To enable private repositories, you&apos;ll need to provide a GitHub or
+            Azure Personal Access Token with repo scope. The token will be stored
             locally in your browser. Find out how{" "}
             <Link
               href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -79,7 +81,7 @@ export function PrivateReposDialog({
           </details>
           <Input
             type="password"
-            placeholder="ghp_..."
+            placeholder="personal access token"
             value={pat}
             onChange={(e) => setPat(e.target.value)}
             className="flex-1 rounded-md border-[3px] border-black px-3 py-2 text-base font-bold shadow-[4px_4px_0_0_#000000] placeholder:text-base placeholder:font-normal placeholder:text-gray-700"
@@ -103,7 +105,7 @@ export function PrivateReposDialog({
               </Button>
               <Button
                 type="submit"
-                disabled={!pat.startsWith("ghp_")}
+                disabled={!pat}
                 className="border-[3px] border-black bg-purple-400 px-4 py-2 text-black shadow-[4px_4px_0_0_#000000] transition-transform hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-purple-300 disabled:opacity-50"
               >
                 Save Token

--- a/src/lib/fetch-backend.ts
+++ b/src/lib/fetch-backend.ts
@@ -25,7 +25,8 @@ interface CostApiResponse {
 export async function generateAndCacheDiagram(
   username: string,
   repo: string,
-  github_pat?: string,
+  provider: string,
+  pat?: string,
   instructions?: string,
   api_key?: string,
 ): Promise<GenerateApiResponse> {
@@ -42,9 +43,11 @@ export async function generateAndCacheDiagram(
       body: JSON.stringify({
         username,
         repo,
+        provider,
         instructions: instructions ?? "",
         api_key: api_key,
-        github_pat: github_pat,
+        github_pat: provider === "github" ? pat : undefined,
+        azure_pat: provider === "azure" ? pat : undefined,
       }),
     });
 
@@ -131,8 +134,9 @@ export async function modifyAndCacheDiagram(
 export async function getCostOfGeneration(
   username: string,
   repo: string,
+  provider: string,
   instructions: string,
-  github_pat?: string,
+  pat?: string,
 ): Promise<CostApiResponse> {
   try {
     const baseUrl =
@@ -147,7 +151,9 @@ export async function getCostOfGeneration(
       body: JSON.stringify({
         username,
         repo,
-        github_pat: github_pat,
+        provider,
+        github_pat: provider === "github" ? pat : undefined,
+        azure_pat: provider === "azure" ? pat : undefined,
         instructions: instructions ?? "",
       }),
     });


### PR DESCRIPTION
## Summary
- add AzureDevOpsService for repository operations
- generalize generation router to support GitHub and Azure providers
- update frontend to detect Azure URLs and send provider info
- allow storing Azure personal access tokens
- document Azure support and add AZURE_PAT example

## Testing
- `pnpm lint` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_683b88406d5c832eb4831f082537a178